### PR TITLE
feat(camping): detail screen — issue #7

### DIFF
--- a/.claude/hooks/architecture-guard.sh
+++ b/.claude/hooks/architecture-guard.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Hook: Guardrail for Screaming Architecture
+# Event: PreToolUse | Matcher: Write
+# Asks confirmation when creating .ts/.tsx files outside valid locations
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Only check TypeScript/TSX files
+if [[ ! "$FILE_PATH" =~ \.(ts|tsx)$ ]]; then
+  exit 0
+fi
+
+# Valid locations for .ts/.tsx files (relative to project root)
+# app/ — Expo Router pages/layouts
+# src/domains/ — Screaming architecture bounded contexts
+# src/shared/ — Shared cross-domain code
+# src/infrastructure/ — External service adapters
+# .claude/ — Claude skills and hooks
+# __tests__/ or __mocks__/ — Test files anywhere
+# *.test.ts(x) / *.spec.ts(x) — Test files
+# *.d.ts — Type declarations
+
+# Skip test files
+if [[ "$FILE_PATH" =~ \.(test|spec)\.(ts|tsx)$ ]] || echo "$FILE_PATH" | grep -qE '(__tests__|__mocks__)/'; then
+  exit 0
+fi
+
+# Skip type declarations
+if [[ "$FILE_PATH" =~ \.d\.ts$ ]]; then
+  exit 0
+fi
+
+# Skip config files at root level
+FILENAME=$(basename "$FILE_PATH")
+if [[ "$FILENAME" =~ ^(babel|metro|tailwind|nativewind-env|app\.config|tsconfig|jest\.config|env)\. ]]; then
+  exit 0
+fi
+
+# Check if file is in a valid location
+if echo "$FILE_PATH" | grep -qE '(^|/)app/' || \
+   echo "$FILE_PATH" | grep -qE '(^|/)src/domains/' || \
+   echo "$FILE_PATH" | grep -qE '(^|/)src/shared/' || \
+   echo "$FILE_PATH" | grep -qE '(^|/)src/infrastructure/' || \
+   echo "$FILE_PATH" | grep -qE '(^|/)\.claude/'; then
+  exit 0
+fi
+
+# File is outside valid locations — ask for confirmation
+jq -n --arg path "$FILE_PATH" '{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": ("File " + $path + " is outside the Screaming Architecture (app/, src/domains/, src/shared/, src/infrastructure/). Are you sure this is the right location?")
+  }
+}'

--- a/.claude/hooks/post-compact-context.sh
+++ b/.claude/hooks/post-compact-context.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Hook: Re-inject context after compaction
+# Event: SessionStart | Matcher: compact
+# Restores essential project context that gets lost during compaction
+
+INPUT=$(cat)
+SOURCE=$(echo "$INPUT" | jq -r '.source // empty')
+
+# Only run after compaction
+if [[ "$SOURCE" != "compact" ]]; then
+  exit 0
+fi
+
+PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // empty')
+if [[ -z "$PROJECT_DIR" ]]; then
+  PROJECT_DIR="/Users/zuricata/Documents/dev/xplorers"
+fi
+
+cd "$PROJECT_DIR" || exit 0
+
+# Gather context
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+MODIFIED=$(git diff --name-only 2>/dev/null | head -20)
+STAGED=$(git diff --cached --name-only 2>/dev/null | head -20)
+DOMAINS=$(ls src/domains/ 2>/dev/null | tr '\n' ', ' | sed 's/,$//')
+
+# Build context message
+CONTEXT="## Post-Compaction Context Restore
+
+**Project**: Xplorers — Camping directory app for Argentina
+**Phase**: Fase 1 — MVP Directorio
+**Branch**: $BRANCH
+**Architecture**: Screaming Architecture with bounded domains in src/domains/
+
+**Active domains**: $DOMAINS
+
+**Key rules**:
+- No ESLint/Prettier — only quality gate is \`npx tsc --noEmit\`
+- Conventional commits only, NO Co-Authored-By
+- Use bat/rg/fd/sd/eza instead of cat/grep/find/sed/ls
+- Stack: Expo SDK 55, NativeWind v4 + TW3, Zustand 5, TanStack Query v5, Supabase PostGIS"
+
+if [[ -n "$MODIFIED" ]]; then
+  CONTEXT="$CONTEXT
+
+**Modified files (unstaged)**:
+$MODIFIED"
+fi
+
+if [[ -n "$STAGED" ]]; then
+  CONTEXT="$CONTEXT
+
+**Staged files**:
+$STAGED"
+fi
+
+jq -n --arg ctx "$CONTEXT" '{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": $ctx
+  }
+}'

--- a/.claude/hooks/protect-env.sh
+++ b/.claude/hooks/protect-env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Hook: Protect .env files from editing/writing
+# Event: PreToolUse | Matcher: Edit|Write
+# Blocks modification of .env files — suggest .env.example instead
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Get just the filename
+FILENAME=$(basename "$FILE_PATH")
+
+# Allow .env.example (safe to edit)
+if [[ "$FILENAME" == ".env.example" ]]; then
+  exit 0
+fi
+
+# Check if it's a .env file
+if [[ "$FILENAME" == ".env" || "$FILENAME" == ".env.local" || "$FILENAME" == ".env.production" || "$FILENAME" == ".env.development" || "$FILENAME" =~ ^\.env\. ]]; then
+  jq -n '{
+    "hookSpecificOutput": {
+      "hookEventName": "PreToolUse",
+      "permissionDecision": "deny",
+      "permissionDecisionReason": "Editing .env files is blocked to protect secrets (Supabase, Mapbox keys). Edit .env.example instead and let the user update .env manually."
+    }
+  }'
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/protect-migrations.sh
+++ b/.claude/hooks/protect-migrations.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Hook: Protect existing Supabase migrations from editing
+# Event: PreToolUse | Matcher: Edit
+# Existing migrations are immutable once applied. Create new ones instead.
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Check if the file is inside supabase/migrations/
+if echo "$FILE_PATH" | grep -q 'supabase/migrations/'; then
+  # Only block if the file already exists (Edit on existing migration)
+  if [[ -f "$FILE_PATH" ]]; then
+    jq -n '{
+      "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": "Existing migrations are immutable — they have already been applied to the database. Create a new migration instead with `npm run db:migration:new <name>`."
+      }
+    }'
+    exit 0
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/typecheck-on-stop.sh
+++ b/.claude/hooks/typecheck-on-stop.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Hook: Run typecheck when Claude finishes
+# Event: Stop
+# Only quality gate available (no ESLint/tests). Blocks Stop on errors.
+
+INPUT=$(cat)
+
+# Guard against infinite loops: check if we're already in a typecheck cycle
+STOP_HOOK_ACTIVE=$(echo "$INPUT" | jq -r '.stop_hook_active // false')
+MARKER="/tmp/xplorers-typecheck-$$"
+
+# Use a project-level marker to detect loops
+LOOP_MARKER="/tmp/xplorers-typecheck-loop"
+if [[ -f "$LOOP_MARKER" ]]; then
+  LAST_RUN=$(cat "$LOOP_MARKER")
+  NOW=$(date +%s)
+  # If last run was less than 30 seconds ago, we're likely in a loop
+  if (( NOW - LAST_RUN < 30 )); then
+    rm -f "$LOOP_MARKER"
+    exit 0  # Allow stop to prevent infinite loop
+  fi
+fi
+
+# Record this run
+date +%s > "$LOOP_MARKER"
+
+# Run typecheck from project root
+PROJECT_DIR=$(echo "$INPUT" | jq -r '.cwd // empty')
+if [[ -z "$PROJECT_DIR" ]]; then
+  PROJECT_DIR="/Users/zuricata/Documents/dev/xplorers"
+fi
+
+cd "$PROJECT_DIR" || exit 0
+
+TSC_OUTPUT=$(npx tsc --noEmit 2>&1)
+TSC_EXIT=$?
+
+# Clean up loop marker on success
+if [[ $TSC_EXIT -eq 0 ]]; then
+  rm -f "$LOOP_MARKER"
+  exit 0
+fi
+
+# Type errors found — block stop
+ERROR_COUNT=$(echo "$TSC_OUTPUT" | grep -c "error TS")
+ERRORS=$(echo "$TSC_OUTPUT" | grep "error TS" | head -20)
+
+jq -n --arg reason "TypeScript found $ERROR_COUNT error(s). Fix them before finishing:\n$ERRORS" '{
+  "decision": "block",
+  "reason": $reason
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-env.sh", "timeout": 5000 }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/protect-migrations.sh", "timeout": 5000 }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/architecture-guard.sh", "timeout": 5000 }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/typecheck-on-stop.sh", "timeout": 60000 }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "compact",
+        "hooks": [
+          { "type": "command", "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/post-compact-context.sh", "timeout": 10000 }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/gluestack-ui/SKILL.md
+++ b/.claude/skills/gluestack-ui/SKILL.md
@@ -1,0 +1,258 @@
+# Gluestack UI v3 — Xplorers Patterns
+
+Installed packages: `@gluestack-ui/overlay@^0.1.22`, `@gluestack-ui/toast@^1.0.9`, `@gluestack-ui/nativewind-utils@^1.0.28`.
+
+## tva — Tailwind Variants Abstraction
+
+From `@gluestack-ui/nativewind-utils/tva`. Wraps `tailwind-variants` `tv()` with NativeWind support and parent variant merging.
+
+### API
+
+```tsx
+import { tva } from "@gluestack-ui/nativewind-utils/tva";
+
+const chipStyle = tva({
+  base: "rounded-glass-xs px-3 py-1.5 font-label text-sm",
+  variants: {
+    variant: {
+      active: "bg-andes-200 dark:bg-andes-700",
+      inactive: "bg-transparent",
+    },
+    size: {
+      sm: "px-2 py-1 text-xs",
+      md: "px-3 py-1.5 text-sm",
+      lg: "px-4 py-2 text-base",
+    },
+  },
+  defaultVariants: {
+    variant: "inactive",
+    size: "md",
+  },
+});
+
+// Usage
+<View className={chipStyle({ variant: "active", size: "sm" })} />
+```
+
+### Key differences from `cva`
+
+- Supports `parentVariants` / `parentCompoundVariants` for component composition
+- Deep-merges parent + child variants automatically
+- Same slot/compound variant API as `tailwind-variants`
+- Config defaults from `tailwind-variants` `defaultConfig`
+
+### With GlassView levels
+
+```tsx
+const glassCardStyle = tva({
+  base: "rounded-glass p-4",
+  variants: {
+    level: {
+      ultra: "", // glass level handled by GlassView prop, not className
+      mid: "",
+      soft: "",
+      andes: "",
+    },
+    elevated: {
+      true: "shadow-md",
+      false: "",
+    },
+  },
+  defaultVariants: { level: "mid", elevated: false },
+});
+```
+
+> Note: GlassView applies glass styles via `ViewStyle` (not className). Use `tva` for className-based variants (size, spacing, layout) and GlassView `level` prop for the glass effect.
+
+---
+
+## Toast System
+
+From `@gluestack-ui/toast`. Factory pattern for creating toasts.
+
+### Setup
+
+#### 1. Create toast components
+
+```tsx
+// src/shared/components/toast.tsx
+import { createToast, createToastHook } from "@gluestack-ui/toast";
+import { Text, View } from "react-native";
+import { Motion, AnimatePresence } from "@legendapp/motion"; // or Animated wrapper
+
+import { GlassView } from "@/src/shared/components/GlassView";
+
+// Create the hook (animation wrapper can be a simple View if no animations)
+export const useToast = createToastHook(Motion.View, AnimatePresence);
+// Or without animations:
+// export const useToast = createToastHook(View, ({ children }: any) => <>{children}</>);
+
+// Create styled toast
+export const Toast = createToast({
+  Root: GlassView,   // Use GlassView as toast container
+  Title: Text,
+  Description: Text,
+});
+```
+
+#### 2. Add ToastProvider to root layout
+
+```tsx
+// app/_layout.tsx
+import { ToastProvider } from "@gluestack-ui/toast";
+
+export default function RootLayout() {
+  return (
+    <ToastProvider>
+      {/* ...existing providers and Slot/Stack */}
+    </ToastProvider>
+  );
+}
+```
+
+### Usage
+
+```tsx
+const toast = useToast();
+
+toast.show({
+  placement: "bottom",        // "top" | "bottom" | "top right" | "top left" | "bottom left" | "bottom right"
+  duration: 3000,             // ms, null = never dismiss
+  avoidKeyboard: true,
+  render: ({ id }) => (
+    <Toast nativeID={`toast-${id}`} level="andes" className="mx-4 rounded-glass p-4">
+      <Toast.Title className="font-heading text-sm text-andes-800 dark:text-andes-100">
+        Guardado
+      </Toast.Title>
+      <Toast.Description className="font-body text-xs text-andes-700 dark:text-andes-200">
+        El camping fue agregado a favoritos
+      </Toast.Description>
+    </Toast>
+  ),
+});
+
+// Other methods
+toast.close(id);       // dismiss specific toast
+toast.closeAll();      // dismiss all
+toast.isActive(id);    // check if visible
+```
+
+### Toast types by glass level
+
+| Intent    | Glass level   | Example                          |
+|-----------|---------------|----------------------------------|
+| Success   | `andes`       | "Guardado", "Favorito agregado"  |
+| Info      | `glaciar`     | "Sincronizando...", "Actualizado"|
+| Warning   | `crepusculo`  | "Sin conexión", "Límite cercano" |
+| Neutral   | `mid`         | Generic feedback                 |
+
+---
+
+## Overlay
+
+From `@gluestack-ui/overlay`. For partial overlays (tooltips, popovers, dropdowns). NOT for full-screen modals.
+
+### Setup
+
+```tsx
+// app/_layout.tsx
+import { OverlayProvider } from "@gluestack-ui/overlay";
+
+export default function RootLayout() {
+  return (
+    <OverlayProvider>
+      {/* ...existing providers */}
+    </OverlayProvider>
+  );
+}
+```
+
+### API
+
+```tsx
+import { Overlay } from "@gluestack-ui/overlay";
+
+<Overlay
+  isOpen={isVisible}
+  onRequestClose={onClose}
+  animationPreset="fade"           // "fade" | "slide" | "none"
+  useRNModal={false}               // true = uses RN Modal (better a11y on Android)
+  isKeyboardDismissable={true}     // ESC / back button dismisses
+>
+  {/* Overlay content */}
+</Overlay>
+```
+
+### When to use Overlay vs Modal
+
+| Use case                        | Component                                      |
+|---------------------------------|------------------------------------------------|
+| Full-screen sheet / form        | RN `Modal` + `presentationStyle="pageSheet"`   |
+| Filter/sort panel               | RN `Modal` (see FilterModal.tsx pattern)        |
+| Image gallery viewer            | RN `Modal` + `presentationStyle="overFullScreen"` |
+| Tooltip / popover               | Gluestack `Overlay`                            |
+| Dropdown menu                   | Gluestack `Overlay`                            |
+| Confirmation dialog (small)     | Gluestack `Overlay` + `useRNModal` on Android  |
+
+---
+
+## Project Modal Pattern (established)
+
+The project uses RN `Modal` directly with `GlassView` for full-screen modals. This is the canonical pattern — do NOT replace it with Gluestack Overlay for full modals.
+
+### Reference: `src/domains/camping/components/FilterModal.tsx`
+
+```tsx
+import { Modal, Pressable, ScrollView, Text, useColorScheme, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { GlassView } from "@/src/shared/components/GlassView";
+import { glassText } from "@/src/shared/theme/tokens";
+
+interface ModalProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export function ExampleModal({ visible, onClose }: ModalProps) {
+  const dark = useColorScheme() === "dark";
+  const colors = dark ? glassText.dark : glassText.light;
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"     // iOS sheet presentation
+      onRequestClose={onClose}          // Android back button
+    >
+      <View
+        className="flex-1 bg-[#fafbfc] dark:bg-[#1e2730]"
+        style={{ paddingTop: insets.top }}
+      >
+        {/* Header: title + close button */}
+        {/* Content: ScrollView */}
+        {/* Footer: action buttons with insets.bottom padding */}
+      </View>
+    </Modal>
+  );
+}
+```
+
+### Key conventions
+
+- `presentationStyle="pageSheet"` for iOS native sheet behavior
+- `onRequestClose` always wired for Android back button
+- `useSafeAreaInsets()` for top/bottom padding
+- Background: `bg-[#fafbfc] dark:bg-[#1e2730]` (semantic.light/dark.bg.base)
+- Text colors via `glassText.dark/light` for WCAG AA contrast
+- Close button: icon in rounded muted background
+- GlassView chips for interactive elements (filters, tags)
+
+---
+
+## Reference Files
+
+- `src/shared/components/GlassView.tsx` — reusable glass component (blur + opaque fallback)
+- `src/shared/theme/glass.ts` — 7 glass presets: ultra, mid, soft, andes, glaciar, crepusculo, btn
+- `src/shared/theme/tokens.ts` — color scales, semantic values, glassText (WCAG AA)
+- `src/domains/camping/components/FilterModal.tsx` — canonical modal pattern

--- a/app.json
+++ b/app.json
@@ -49,7 +49,8 @@
           "locationAlwaysAndWhenInUsePermission": "Xplorers usa tu ubicación para mostrarte campings cercanos y verificar check-ins."
         }
       ],
-      "@rnmapbox/maps"
+      "@rnmapbox/maps",
+      "expo-image"
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/camping/[id]/index.tsx
+++ b/app/camping/[id]/index.tsx
@@ -1,20 +1,186 @@
-import { View, Text } from "react-native";
-import { useLocalSearchParams, Stack } from "expo-router";
+import { useRouter, useLocalSearchParams, Stack } from "expo-router";
+import { AlertTriangle, ChevronLeft, ShieldCheck } from "lucide-react-native";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+  useColorScheme,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { GlassView } from "@/src/shared/components/GlassView";
+import { glassText } from "@/src/shared/theme/tokens";
+import { useCamping } from "@/src/domains/camping/hooks";
+import { CAMPING_TYPE_LABELS } from "@/src/domains/camping/types";
+import { CampingDetailHero } from "@/src/domains/camping/components/CampingDetailHero";
+import { CampingAmenitiesGrid } from "@/src/domains/camping/components/CampingAmenitiesGrid";
+import { CampingPricesSection } from "@/src/domains/camping/components/CampingPricesSection";
+import { CampingContactSection } from "@/src/domains/camping/components/CampingContactSection";
+import { ReportErrorModal } from "@/src/domains/camping/components/ReportErrorModal";
 
 export default function CampingDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const dark = useColorScheme() === "dark";
+  const colors = dark ? glassText.dark : glassText.light;
+
+  const { data: camping, isPending, error } = useCamping(id!);
+  const [isReportOpen, setIsReportOpen] = useState(false);
+
+  if (isPending) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View className="flex-1 items-center justify-center bg-[#fafbfc] dark:bg-[#1e2730]">
+          <ActivityIndicator size="large" color={colors.brand} />
+        </View>
+      </>
+    );
+  }
+
+  if (error || !camping) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View
+          className="flex-1 items-center justify-center bg-[#fafbfc] px-6 dark:bg-[#1e2730]"
+          style={{ paddingTop: insets.top }}
+        >
+          <Text
+            className="font-body text-base text-center"
+            style={{ color: colors.secondary }}
+          >
+            No se pudo cargar el camping.
+          </Text>
+          <Pressable className="mt-4" onPress={() => router.back()}>
+            <Text
+              className="font-label text-sm uppercase"
+              style={{ color: colors.brand }}
+            >
+              Volver
+            </Text>
+          </Pressable>
+        </View>
+      </>
+    );
+  }
 
   return (
     <>
-      <Stack.Screen options={{ title: "Camping" }} />
-      <View className="flex-1 items-center justify-center bg-white dark:bg-neutral-900">
-        <Text className="text-lg font-semibold text-neutral-900 dark:text-white">
-          Detalle de Camping
-        </Text>
-        <Text className="mt-2 text-sm text-neutral-500">ID: {id}</Text>
-        <Text className="mt-1 text-sm text-neutral-500">
-          Implementación completa — issue #7
-        </Text>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View className="flex-1 bg-[#fafbfc] dark:bg-[#1e2730]">
+        {/* Header */}
+        <View
+          className="flex-row items-center gap-2 px-4 pb-2"
+          style={{ paddingTop: insets.top + 8 }}
+        >
+          <Pressable onPress={() => router.back()} hitSlop={8}>
+            <View className="rounded-full bg-[#e3eaef] p-1.5 dark:bg-[#36424d]">
+              <ChevronLeft size={20} color={colors.primary} />
+            </View>
+          </Pressable>
+          <Text
+            className="flex-1 font-heading text-lg"
+            style={{ color: colors.primary }}
+            numberOfLines={1}
+          >
+            {camping.name}
+          </Text>
+        </View>
+
+        {/* Content */}
+        <ScrollView
+          className="flex-1"
+          showsVerticalScrollIndicator={false}
+          contentContainerClassName="pb-8"
+        >
+          <CampingDetailHero photos={camping.photos ?? []} />
+
+          {/* Type + Verified badges */}
+          <View className="mt-4 flex-row items-center gap-2 px-4">
+            {camping.type && (
+              <GlassView level="andes" className="rounded-glass-xs px-3 py-1">
+                <Text
+                  className="font-label text-xs"
+                  style={{ color: colors.brand }}
+                >
+                  {CAMPING_TYPE_LABELS[camping.type]}
+                </Text>
+              </GlassView>
+            )}
+            {camping.verified && (
+              <GlassView
+                level="glaciar"
+                className="flex-row items-center gap-1 rounded-glass-xs px-3 py-1"
+              >
+                <ShieldCheck size={12} color={colors.glaciar} />
+                <Text
+                  className="font-label text-xs"
+                  style={{ color: colors.glaciar }}
+                >
+                  Verificado
+                </Text>
+              </GlassView>
+            )}
+          </View>
+
+          {/* Province */}
+          <Text
+            className="mt-3 px-4 font-body text-sm"
+            style={{ color: colors.secondary }}
+          >
+            {camping.province}
+          </Text>
+
+          {/* Amenities */}
+          <View className="mt-6">
+            <CampingAmenitiesGrid
+              amenities={camping.amenities ?? {}}
+            />
+          </View>
+
+          {/* Prices */}
+          <View className="mt-6">
+            <CampingPricesSection prices={camping.prices ?? null} />
+          </View>
+
+          {/* Contact */}
+          <View className="mt-6">
+            <CampingContactSection
+              contact={camping.contact ?? null}
+              campingName={camping.name}
+            />
+          </View>
+        </ScrollView>
+
+        {/* Footer — Report button */}
+        <View
+          className="border-t border-[#e3eaef] px-4 py-3 dark:border-[#36424d]"
+          style={{ paddingBottom: insets.bottom + 12 }}
+        >
+          <Pressable
+            className="flex-row items-center justify-center gap-2 rounded-glass-sm bg-[#e3eaef] py-3 dark:bg-[#36424d]"
+            onPress={() => setIsReportOpen(true)}
+          >
+            <AlertTriangle size={16} color={colors.accent} />
+            <Text
+              className="font-label text-sm uppercase tracking-wide"
+              style={{ color: colors.secondary }}
+            >
+              Reportar error
+            </Text>
+          </Pressable>
+        </View>
+
+        <ReportErrorModal
+          visible={isReportOpen}
+          onClose={() => setIsReportOpen(false)}
+          campingId={id!}
+        />
       </View>
     </>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "expo-blur": "^55.0.8",
         "expo-constants": "~55.0.7",
         "expo-font": "~55.0.4",
+        "expo-haptics": "~55.0.8",
+        "expo-image": "~55.0.5",
         "expo-linking": "~55.0.7",
         "expo-location": "^55.1.2",
         "expo-notifications": "^55.0.10",
@@ -5814,6 +5816,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-haptics": {
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-55.0.8.tgz",
+      "integrity": "sha512-yVR6EsQwl1WuhFITc0PpfI/7dsBdjK/F2YA8xB80UUW9iTa+Tqz21FpH4n/vtbargpzFxkhl5WNYMa419+QWFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-image": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "expo-blur": "^55.0.8",
     "expo-constants": "~55.0.7",
     "expo-font": "~55.0.4",
+    "expo-haptics": "~55.0.8",
+    "expo-image": "~55.0.5",
     "expo-linking": "~55.0.7",
     "expo-location": "^55.1.2",
     "expo-notifications": "^55.0.10",

--- a/src/domains/camping/components/CampingAmenitiesGrid.tsx
+++ b/src/domains/camping/components/CampingAmenitiesGrid.tsx
@@ -1,0 +1,48 @@
+import { Text, View, useColorScheme } from "react-native";
+
+import { GlassView } from "@/src/shared/components/GlassView";
+import { glassText } from "@/src/shared/theme/tokens";
+
+import { AMENITY_LABELS, type AmenityKey } from "../types";
+
+interface CampingAmenitiesGridProps {
+  amenities: Record<string, boolean>;
+}
+
+export function CampingAmenitiesGrid({ amenities }: CampingAmenitiesGridProps) {
+  const dark = useColorScheme() === "dark";
+  const colors = dark ? glassText.dark : glassText.light;
+
+  return (
+    <View className="px-4">
+      <Text
+        className="mb-3 font-label text-sm uppercase tracking-wider"
+        style={{ color: colors.secondary }}
+      >
+        Servicios
+      </Text>
+      <View className="flex-row flex-wrap gap-2">
+        {(Object.keys(AMENITY_LABELS) as AmenityKey[]).map((key) => {
+          const active = amenities[key] === true;
+          return (
+            <GlassView
+              key={key}
+              level={active ? "andes" : "btn"}
+              className="w-[31%] items-center rounded-glass-xs px-2 py-2.5"
+              style={active ? undefined : { opacity: 0.5 }}
+            >
+              <Text
+                className="text-center font-label text-xs"
+                style={{
+                  color: active ? colors.brand : colors.secondary,
+                }}
+              >
+                {AMENITY_LABELS[key]}
+              </Text>
+            </GlassView>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/src/domains/camping/components/CampingContactSection.tsx
+++ b/src/domains/camping/components/CampingContactSection.tsx
@@ -1,0 +1,108 @@
+import * as Haptics from "expo-haptics";
+import { Globe, Mail, MessageCircle, Phone } from "lucide-react-native";
+import { Linking, Pressable, Text, View, useColorScheme } from "react-native";
+
+import { GlassView } from "@/src/shared/components/GlassView";
+import { glassText } from "@/src/shared/theme/tokens";
+
+import type { Contact } from "../types";
+
+interface ContactAction {
+  key: string;
+  icon: typeof Phone;
+  label: string;
+  url: string;
+}
+
+interface CampingContactSectionProps {
+  contact: Contact | null;
+  campingName: string;
+}
+
+export function CampingContactSection({
+  contact,
+  campingName,
+}: CampingContactSectionProps) {
+  const dark = useColorScheme() === "dark";
+  const colors = dark ? glassText.dark : glassText.light;
+
+  if (!contact) return null;
+
+  const actions: ContactAction[] = [];
+
+  if (contact.phone) {
+    actions.push({
+      key: "phone",
+      icon: Phone,
+      label: contact.phone,
+      url: `tel:${contact.phone}`,
+    });
+  }
+
+  if (contact.whatsapp) {
+    const text = encodeURIComponent(
+      `Hola! Quería consultar sobre ${campingName}`,
+    );
+    actions.push({
+      key: "whatsapp",
+      icon: MessageCircle,
+      label: "WhatsApp",
+      url: `whatsapp://send?phone=${contact.whatsapp}&text=${text}`,
+    });
+  }
+
+  if (contact.email) {
+    actions.push({
+      key: "email",
+      icon: Mail,
+      label: contact.email,
+      url: `mailto:${contact.email}`,
+    });
+  }
+
+  if (contact.website) {
+    actions.push({
+      key: "website",
+      icon: Globe,
+      label: contact.website.replace(/^https?:\/\//, ""),
+      url: contact.website,
+    });
+  }
+
+  if (actions.length === 0) return null;
+
+  const handlePress = (url: string) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    Linking.openURL(url);
+  };
+
+  return (
+    <View className="px-4">
+      <Text
+        className="mb-3 font-label text-sm uppercase tracking-wider"
+        style={{ color: colors.secondary }}
+      >
+        Contacto
+      </Text>
+      <View className="gap-2">
+        {actions.map(({ key, icon: Icon, label, url }) => (
+          <Pressable key={key} onPress={() => handlePress(url)}>
+            <GlassView
+              level="btn"
+              className="flex-row items-center gap-3 rounded-glass-sm px-4 py-3"
+            >
+              <Icon size={18} color={colors.brand} />
+              <Text
+                className="flex-1 font-body text-sm"
+                style={{ color: colors.primary }}
+                numberOfLines={1}
+              >
+                {label}
+              </Text>
+            </GlassView>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/src/domains/camping/components/CampingDetailHero.tsx
+++ b/src/domains/camping/components/CampingDetailHero.tsx
@@ -1,0 +1,78 @@
+import { Image } from "expo-image";
+import { Mountain } from "lucide-react-native";
+import { useState } from "react";
+import {
+  ScrollView,
+  Text,
+  View,
+  useColorScheme,
+  useWindowDimensions,
+} from "react-native";
+
+import { GlassView } from "@/src/shared/components/GlassView";
+import { glassText } from "@/src/shared/theme/tokens";
+
+interface CampingDetailHeroProps {
+  photos: string[];
+}
+
+export function CampingDetailHero({ photos }: CampingDetailHeroProps) {
+  const dark = useColorScheme() === "dark";
+  const colors = dark ? glassText.dark : glassText.light;
+  const { width } = useWindowDimensions();
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  if (photos.length === 0) {
+    return (
+      <GlassView level="soft" className="h-60 items-center justify-center">
+        <Mountain size={64} color={colors.secondary} />
+        <Text
+          className="mt-3 font-body text-sm"
+          style={{ color: colors.secondary }}
+        >
+          Sin fotos disponibles
+        </Text>
+      </GlassView>
+    );
+  }
+
+  return (
+    <View>
+      <ScrollView
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={(e) => {
+          const index = Math.round(e.nativeEvent.contentOffset.x / width);
+          setActiveIndex(index);
+        }}
+      >
+        {photos.map((uri, i) => (
+          <Image
+            key={uri}
+            source={{ uri }}
+            contentFit="cover"
+            style={{ width, height: 280 }}
+            alt={`Foto ${i + 1}`}
+          />
+        ))}
+      </ScrollView>
+      {photos.length > 1 && (
+        <View className="absolute bottom-3 flex-row self-center gap-1.5">
+          {photos.map((uri, i) => (
+            <View
+              key={uri}
+              className="h-2 w-2 rounded-full"
+              style={{
+                backgroundColor:
+                  i === activeIndex
+                    ? "rgba(255,255,255,0.9)"
+                    : "rgba(255,255,255,0.4)",
+              }}
+            />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}

--- a/src/domains/camping/components/CampingPricesSection.tsx
+++ b/src/domains/camping/components/CampingPricesSection.tsx
@@ -1,0 +1,86 @@
+import { Text, View, useColorScheme } from "react-native";
+
+import { GlassView } from "@/src/shared/components/GlassView";
+import { glassText } from "@/src/shared/theme/tokens";
+
+const PRICE_LABELS: Record<string, string> = {
+  tent_per_night: "Carpa / noche",
+  car_per_night: "Auto / noche",
+  person_per_night: "Persona / noche",
+  motorhome_per_night: "Motorhome / noche",
+};
+
+function formatPrice(
+  amount: number,
+  currency: string = "ARS",
+): string {
+  if (currency === "SAT") return `${amount} SAT`;
+  if (currency === "USD") return `US$ ${amount.toLocaleString()}`;
+  return `$ ${amount.toLocaleString()}`;
+}
+
+interface CampingPricesSectionProps {
+  prices: Record<string, number | string> | null;
+}
+
+export function CampingPricesSection({ prices }: CampingPricesSectionProps) {
+  const dark = useColorScheme() === "dark";
+  const colors = dark ? glassText.dark : glassText.light;
+
+  if (!prices) return null;
+
+  const currency = typeof prices.currency === "string" ? prices.currency : "ARS";
+  const updatedAt = typeof prices.updated_at === "string" ? prices.updated_at : null;
+
+  const priceEntries = Object.entries(prices).filter(
+    ([key, val]) =>
+      key !== "currency" && key !== "updated_at" && typeof val === "number",
+  );
+
+  if (priceEntries.length === 0) return null;
+
+  return (
+    <View className="px-4">
+      <Text
+        className="mb-3 font-label text-sm uppercase tracking-wider"
+        style={{ color: colors.secondary }}
+      >
+        Precios
+      </Text>
+      <GlassView level="mid" className="rounded-glass p-4">
+        {priceEntries.map(([key, val], i) => (
+          <View
+            key={key}
+            className={`flex-row items-center justify-between ${i > 0 ? "mt-3 border-t border-[#e3eaef] pt-3 dark:border-[#36424d]" : ""}`}
+          >
+            <Text
+              className="font-body text-sm"
+              style={{ color: colors.secondary }}
+            >
+              {PRICE_LABELS[key] ?? key}
+            </Text>
+            <Text
+              className="font-heading text-base"
+              style={{ color: colors.primary }}
+            >
+              {formatPrice(val as number, currency)}
+            </Text>
+          </View>
+        ))}
+        {updatedAt && (
+          <Text
+            className="mt-3 font-body text-xs"
+            style={{ color: colors.secondary, opacity: 0.7 }}
+          >
+            Precios al{" "}
+            {new Date(updatedAt).toLocaleDateString("es-AR", {
+              day: "numeric",
+              month: "long",
+              year: "numeric",
+            })}
+          </Text>
+        )}
+      </GlassView>
+    </View>
+  );
+}

--- a/src/domains/camping/components/ReportErrorModal.tsx
+++ b/src/domains/camping/components/ReportErrorModal.tsx
@@ -1,0 +1,184 @@
+import { X } from "lucide-react-native";
+import { useState } from "react";
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+  useColorScheme,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { GlassView } from "@/src/shared/components/GlassView";
+import { glassText } from "@/src/shared/theme/tokens";
+
+import { useReportError } from "../hooks";
+import { ERROR_REPORT_TYPES, type ErrorReportType } from "../types";
+
+interface ReportErrorModalProps {
+  visible: boolean;
+  onClose: () => void;
+  campingId: string;
+}
+
+export function ReportErrorModal({
+  visible,
+  onClose,
+  campingId,
+}: ReportErrorModalProps) {
+  const dark = useColorScheme() === "dark";
+  const colors = dark ? glassText.dark : glassText.light;
+  const insets = useSafeAreaInsets();
+
+  const [selectedType, setSelectedType] = useState<ErrorReportType | null>(
+    null,
+  );
+  const [description, setDescription] = useState("");
+
+  const mutation = useReportError();
+
+  const handleSubmit = () => {
+    if (!selectedType) return;
+    mutation.mutate(
+      {
+        camping_id: campingId,
+        type: selectedType,
+        description: description.trim() || "",
+      },
+      {
+        onSuccess: () => {
+          setSelectedType(null);
+          setDescription("");
+          onClose();
+        },
+      },
+    );
+  };
+
+  const handleClose = () => {
+    if (!mutation.isPending) {
+      setSelectedType(null);
+      setDescription("");
+      mutation.reset();
+      onClose();
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={handleClose}
+    >
+      <View
+        className="flex-1 bg-[#fafbfc] dark:bg-[#1e2730]"
+        style={{ paddingTop: insets.top }}
+      >
+        {/* Header */}
+        <View className="flex-row items-center justify-between px-4 py-3">
+          <Text
+            className="font-heading text-xl uppercase tracking-wide"
+            style={{ color: colors.primary }}
+          >
+            Reportar error
+          </Text>
+          <Pressable onPress={handleClose} hitSlop={8}>
+            <View className="rounded-full bg-[#e3eaef] p-1.5 dark:bg-[#36424d]">
+              <X size={18} color={colors.secondary} />
+            </View>
+          </Pressable>
+        </View>
+
+        <ScrollView
+          className="flex-1"
+          contentContainerClassName="px-4 pb-8"
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Type selection */}
+          <Text
+            className="mb-2 mt-4 font-label text-sm uppercase tracking-wider"
+            style={{ color: colors.secondary }}
+          >
+            Tipo de error
+          </Text>
+          <View className="flex-row flex-wrap gap-2">
+            {ERROR_REPORT_TYPES.map(({ value, label }) => {
+              const active = selectedType === value;
+              return (
+                <Pressable
+                  key={value}
+                  onPress={() => setSelectedType(value)}
+                >
+                  <GlassView
+                    level={active ? "andes" : "btn"}
+                    className="rounded-glass-xs px-3 py-1.5"
+                  >
+                    <Text
+                      className="font-label text-sm"
+                      style={{
+                        color: active ? colors.brand : colors.secondary,
+                      }}
+                    >
+                      {label}
+                    </Text>
+                  </GlassView>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          {/* Description */}
+          <Text
+            className="mb-2 mt-6 font-label text-sm uppercase tracking-wider"
+            style={{ color: colors.secondary }}
+          >
+            Descripción (opcional)
+          </Text>
+          <GlassView level="btn" className="rounded-glass-sm">
+            <TextInput
+              className="min-h-[100px] p-3 font-body text-sm"
+              style={{ color: colors.primary, textAlignVertical: "top" }}
+              placeholder="Describí el error que encontraste..."
+              placeholderTextColor={colors.secondary}
+              value={description}
+              onChangeText={setDescription}
+              multiline
+              editable={!mutation.isPending}
+            />
+          </GlassView>
+
+          {/* Error message */}
+          {mutation.isError && (
+            <Text className="mt-3 font-body text-sm text-crepusculo-500">
+              No se pudo enviar el reporte. Intentá de nuevo.
+            </Text>
+          )}
+        </ScrollView>
+
+        {/* Footer */}
+        <View
+          className="border-t border-[#e3eaef] px-4 py-3 dark:border-[#36424d]"
+          style={{ paddingBottom: insets.bottom + 12 }}
+        >
+          <Pressable
+            className={`items-center rounded-glass-sm py-3 ${
+              !selectedType || mutation.isPending
+                ? "bg-andes-500/40 dark:bg-andes-400/40"
+                : "bg-andes-500 dark:bg-andes-400"
+            }`}
+            onPress={handleSubmit}
+            disabled={!selectedType || mutation.isPending}
+          >
+            <Text className="font-label text-sm uppercase tracking-wide text-white dark:text-[#0e3620]">
+              {mutation.isPending ? "Enviando..." : "Enviar reporte"}
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/domains/camping/components/index.ts
+++ b/src/domains/camping/components/index.ts
@@ -1,5 +1,10 @@
+export { CampingAmenitiesGrid } from "./CampingAmenitiesGrid";
 export { CampingCard } from "./CampingCard";
+export { CampingContactSection } from "./CampingContactSection";
+export { CampingDetailHero } from "./CampingDetailHero";
+export { CampingPricesSection } from "./CampingPricesSection";
 export { FilterChips } from "./FilterChips";
 export { FilterModal } from "./FilterModal";
+export { ReportErrorModal } from "./ReportErrorModal";
 export { SearchInput } from "./SearchInput";
 export { SortPicker } from "./SortPicker";

--- a/src/domains/camping/hooks.ts
+++ b/src/domains/camping/hooks.ts
@@ -1,16 +1,18 @@
 import {
   keepPreviousData,
   useInfiniteQuery,
+  useMutation,
   useQuery,
 } from "@tanstack/react-query";
 import { useShallow } from "zustand/react/shallow";
 
 import { supabase } from "@/src/infrastructure/supabase/client";
+import type { Database } from "@/src/infrastructure/supabase/types";
 import { useDebouncedValue } from "@/src/shared/hooks/useDebouncedValue";
 import type { ViewportBounds } from "@/src/domains/map/types";
 
 import { useFilterStore } from "./store";
-import type { Camping } from "./types";
+import type { Camping, ErrorReportType } from "./types";
 
 export type CampingWithDistance = Camping & { distance_km: number | null };
 
@@ -62,6 +64,8 @@ export function useCampingsInBBox(bounds: ViewportBounds | null) {
   });
 }
 
+export type CampingRow = Database["public"]["Tables"]["campings"]["Row"];
+
 export function useCamping(id: string) {
   return useQuery({
     queryKey: ["campings", id],
@@ -73,7 +77,7 @@ export function useCamping(id: string) {
         .single();
 
       if (error) throw error;
-      return data;
+      return data as unknown as CampingRow;
     },
     enabled: !!id,
   });
@@ -148,5 +152,21 @@ export function useCampingsByProvince(province: string) {
       return data;
     },
     enabled: !!province,
+  });
+}
+
+export function useReportError() {
+  return useMutation({
+    mutationFn: async (payload: {
+      camping_id: string;
+      type: ErrorReportType;
+      description: string;
+    }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const { error } = await (supabase.from("error_reports") as any).insert(
+        payload,
+      );
+      if (error) throw error;
+    },
   });
 }

--- a/src/domains/camping/types.ts
+++ b/src/domains/camping/types.ts
@@ -116,3 +116,13 @@ export const CAMPING_TYPE_LABELS: Record<CampingType, string> = {
   privado: "Privado",
   libre: "Libre",
 };
+
+export const ERROR_REPORT_TYPES = [
+  { value: "wrong_location", label: "Ubicación incorrecta" },
+  { value: "closed", label: "Cerrado permanentemente" },
+  { value: "wrong_info", label: "Información incorrecta" },
+  { value: "duplicate", label: "Duplicado" },
+  { value: "other", label: "Otro" },
+] as const;
+
+export type ErrorReportType = (typeof ERROR_REPORT_TYPES)[number]["value"];

--- a/src/infrastructure/supabase/types.ts
+++ b/src/infrastructure/supabase/types.ts
@@ -50,6 +50,35 @@ export type Database = {
         };
         Update: Partial<Database["public"]["Tables"]["campings"]["Insert"]>;
       };
+      error_reports: {
+        Row: {
+          id: string;
+          camping_id: string;
+          reporter_id: string | null;
+          description: string;
+          type:
+            | "wrong_location"
+            | "closed"
+            | "wrong_info"
+            | "duplicate"
+            | "other";
+          status: "pending" | "reviewed" | "fixed" | "dismissed";
+          created_at: string;
+        };
+        Insert: {
+          camping_id: string;
+          description: string;
+          type:
+            | "wrong_location"
+            | "closed"
+            | "wrong_info"
+            | "duplicate"
+            | "other";
+        };
+        Update: Partial<
+          Database["public"]["Tables"]["error_reports"]["Insert"]
+        >;
+      };
     };
     Functions: {
       get_campings_near: {


### PR DESCRIPTION
## Summary

- Full camping detail screen replacing the stub at `app/camping/[id]/index.tsx`
- Hero section with photo carousel (paginated + dot indicators) or mountain placeholder
- Amenities grid showing all 12 services (active highlighted, inactive dimmed)
- Prices card with ARS/USD/SAT formatting, hidden when no data
- Contact buttons (phone, WhatsApp, email, website) with haptic feedback + `Linking.openURL`
- Report error modal (pageSheet) with type chips + description, powered by `useReportError` mutation
- Added `error_reports` table to Supabase types and `ErrorReportType` to camping domain
- Added `expo-image` and `expo-haptics` dependencies

Closes #7

## Test plan

- [ ] Navigate from discover list or map marker to detail screen
- [ ] Verify hero shows mountain placeholder when no photos exist
- [ ] Verify amenities grid shows 12 items, active ones highlighted in green
- [ ] Verify prices section hidden when `null`, visible with correct formatting when present
- [ ] Verify contact buttons open correct URLs (tel:, whatsapp://, mailto:, https://)
- [ ] Verify haptic feedback on contact button press
- [ ] Open "Reportar error" modal, select type, submit report
- [ ] Verify modal shows error state on failure, closes on success
- [ ] Back button returns to previous screen
- [ ] Loading spinner shows while data loads
- [ ] `npm run typecheck` passes clean